### PR TITLE
update multi-builder to use gulp-chug

### DIFF
--- a/lib/builder/builder.js
+++ b/lib/builder/builder.js
@@ -59,21 +59,21 @@ module.exports = function (gulp, options) {
     plugins.del([
       config.dir.dist + '/**/*',
       config.dir.dist
-    ], cb);
+    ], {force: true}, cb);
   });
 
   gulp.task(prefix('clean:tmp'), function(cb) {
     plugins.del([
       config.dir.tmp + '/**/*',
       config.dir.tmp
-    ], cb);
+    ], {force: true}, cb);
   });
 
   gulp.task(prefix('clean:lib'), function(cb) {
     plugins.del([
       config.dir.lib + '/**/*',
       config.dir.lib
-    ], cb);
+    ], {force: true}, cb);
   });
 
   gulp.task(prefix('lint'), function(cb) {

--- a/lib/builder/multi.js
+++ b/lib/builder/multi.js
@@ -21,65 +21,81 @@ module.exports = function (gulp, options) {
   var config = require('./../util/config')(options);
   var debug = require('gulp-debug');
   var install = require('gulp-install');
-  var fs = require('fs');
   var argv = require('minimist')(process.argv.slice(2));
-  var globby = require('globby');
+  var extend = require('extend');
+  var legacy = require('./../util/legacy');
   var sequence = require('run-sequence').use(gulp);
-  var q = require('q');
-
-  var subtask = false;
-  var component = false;
-  var task = false;
-
-  if (argv._.length > 0 && argv._[0].indexOf('::')) {
-    subtask = argv._[0];
-    component = argv._[0].split('::')[0];
-    task = argv._[0].split('::')[1];
-    if (fs.existsSync(config.path + '/' + component) === false) {
-      subtask = false;
-    }
+  var subTaskUtil = require('./../util/sub-task');
+  var subTask = subTaskUtil.resolveTask();
+  var subArgs = {};
+  if (argv.publish && typeof argv.publish == 'boolean') {
+    subArgs.publish = config.dir.publish;
   }
 
-  gulp.task('install', function() {
-    return gulp.src(config.path + '/*/package.json')
-      .pipe(debug({title: 'installing:'}))
-      .pipe(install({production: true}));
-  });
+  if (subTask) {
+    gulp.task(subTask.gulpTask, function (cb) {
+      var args = {};
+      extend(true, args, subArgs);
+      subTaskUtil.executeTask(gulp, {
+        path: config.path,
+        component: subTask.component,
+        task: subTask.task,
+        args: args
+      }, cb);
+    });
+  }
 
-  gulp.task('build', function(cb) {
-    sequence(
-      'clean',
-      'compile:legacy',
-      'compile',
-      'copy:legacy',
-      cb
-    );
-  });
-
-  gulp.task('compile', function(cb) {
-    getDirectories(function(directories) {
-      if (directories.length > 0) {
-        executeNextSubTask(directories, 'build', {publish: true}, cb);
+  gulp.task('install', function (cb) {
+    subTaskUtil.findComponentDirectories(config.path, function(err, components) {
+      if (components) {
+        components = components.map(function(component) {
+          return component + '/package.json';
+        });
+        var stream = gulp.src(components)
+          .pipe(debug({title: 'installing:'}))
+          .pipe(install({production: true}));
+        stream.on('end', function () {
+          cb();
+        });
       } else {
         cb();
       }
     });
   });
 
-  gulp.task('clean', function(cb) {
+  gulp.task('build', function (cb) {
+    sequence(
+      'clean',
+      'compile:legacy',
+      'copy:legacy',
+      'compile',
+      cb
+    );
+  });
+
+  gulp.task('compile', function (cb) {
+    subTaskUtil.executeTaskOnAllComponents(gulp, {
+      path: config.path,
+      task: 'build',
+      args: {
+        publish: config.dir.publish
+      }
+    }, cb);
+  });
+
+  gulp.task('clean', function (cb) {
     plugins.del([
       config.dir.publish + '/**/*',
       config.dir.publish
     ], cb);
   });
 
-  gulp.task('compile:legacy', function(cb) {
-    getLegacyDirectories(function(directories) {
-
-      directories = directories.map(function(directory) {
+  gulp.task('compile:legacy', function (cb) {
+    if (config.legacy) {
+      var directories = legacy.getDirectories(config);
+      directories = directories.map(function (directory) {
         return directory + '**/*.ts';
       });
-
       if (directories.length > 0) {
         var result = gulp.src(directories, {base: config.path})
           .on('error', plugins.util.log)
@@ -91,23 +107,27 @@ module.exports = function (gulp, options) {
             jsx: 'react',
             typescript: require('ntypescript')
           }));
-
-        var stream = result.js.pipe(plugins.sourcemaps.write({sourceRoot: '../',includeContent: true})).pipe(gulp.dest(config.dir.publish))
-        stream.on('end', function() {
+        var stream = result.js
+          .pipe(plugins.sourcemaps.write({sourceRoot: '../', includeContent: true}))
+          .pipe(gulp.dest(config.dir.publish));
+        stream.on('end', function () {
           cb();
         });
       } else {
         cb();
       }
-    });
+    } else {
+      cb();
+    }
   });
 
-  gulp.task('copy:legacy', ['copy:legacy:files', 'copy:legacy:ui'])
+  gulp.task('copy:legacy', ['copy:legacy:files', 'copy:legacy:ui']);
 
-  gulp.task('copy:legacy:files', function(cb) {
-    getLegacyDirectories(function(directories) {
+  gulp.task('copy:legacy:files', function (cb) {
+    if (config.legacy) {
+      var directories = legacy.getDirectories(config);
       var globs = [];
-      directories.forEach(function(directory) {
+      directories.forEach(function (directory) {
         globs.push(directory + '**/*');
         globs.push('!' + directory + '**/*.ts');
         globs.push('!' + directory + '**/*.ui');
@@ -117,13 +137,16 @@ module.exports = function (gulp, options) {
       } else {
         cb();
       }
-    });
-  })
+    } else {
+      cb();
+    }
+  });
 
-  gulp.task('copy:legacy:ui', function(cb) {
-    getLegacyDirectories(function(directories) {
+  gulp.task('copy:legacy:ui', function (cb) {
+    if (config.legacy) {
+      var directories = legacy.getDirectories(config);
       var globs = [];
-      directories.forEach(function(directory) {
+      directories.forEach(function (directory) {
         globs.push(directory + '**/*.ui');
       });
       if (directories.length > 0) {
@@ -131,65 +154,9 @@ module.exports = function (gulp, options) {
       } else {
         cb();
       }
-    });
-  })
-
-  function getDirectories(cb) {
-    var path = require('path');
-    globby(config.path + '/*/cu-build.config.js', {}, function (er, files) {
-      files = files.map(function(file) {
-        return path.dirname(file);
-      });
-      cb(files);
-    })
-  }
-
-  function getLegacyDirectories(cb) {
-    var fs = require('fs');
-    globby([config.path + '/*/'].concat(config.exclude), {}, function (er, files) {
-      files = files.filter(function(file) {
-        return !fs.existsSync(file + '/cu-build.config.js');
-      });
-      cb(files);
-    })
-  }
-
-  function executeNextSubTask(directories, task, options, cb) {
-    if (directories.length <= 0) {
-      cb();
     } else {
-      var directory = directories.shift();
-      var taskConfig = require(directory + '/cu-build.config.js');
-      if (options.publish) {
-        taskConfig.build_type = 'publish';
-        if (!taskConfig.dir) {
-          taskConfig.dir = {};
-        }
-        taskConfig.dir.publish = config.dir.publish;
-      }
-      taskConfig = require('./../util/config')(taskConfig);
-      executeSubTask(taskConfig, task, function() {
-        executeNextSubTask(directories, task, options, cb);
-      });
-    }
-  }
-
-  function executeSubTask(taskConfig, task, cb) {
-    taskConfig.task_prefix = taskConfig.name + '::';
-    require('./builder')(gulp, taskConfig);
-    var sequence = require('run-sequence').use(gulp);
-    sequence(taskConfig.name + '::' + task, function() {
       cb();
-    });
-  }
-
-  if (subtask) {
-    gulp.task(subtask, function(cb) {
-      var taskConfig = require(config.path + '/' + component + '/cu-build.config.js');
-      executeSubTask(taskConfig, task, function() {
-        cb();
-      });
-    });
-  }
+    }
+  });
 
 };

--- a/lib/util/legacy.js
+++ b/lib/util/legacy.js
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+/**
+ * Get an array of all legacy directories
+ * This will exclude directories listed in "exclude" in "cu-build.config.js"
+ */
+function getDirectories(config) {
+  var fs = require('fs');
+  var globby = require('globby');
+
+  var files = globby.sync([config.path + '/*/'].concat(config.exclude));
+  files = files.filter(function (file) {
+    return !fs.existsSync(file + '/cu-build.config.js');
+  });
+  return files;
+}
+
+module.exports = {
+  getDirectories: getDirectories
+};

--- a/lib/util/sub-task.js
+++ b/lib/util/sub-task.js
@@ -1,0 +1,207 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+/**
+ * Resolve a Sub Task based on process arguments
+ * It should match tasks as "component::task"
+ * It will check that a "cu-build.config.json" exists in the target component directory
+ * Example: component-one::build -> would execute build on component-one
+ */
+function resolveTask() {
+  var argv = require('minimist')(process.argv.slice(2));
+  if (argv._.length > 0) {
+    var parts = argv._[0].split('::');
+    if (parts.length >= 2 && parts[1] != '') {
+      var directory = resolveComponentDirectory(parts[0]);
+      if (directory) {
+        return {
+          component: parts[0],
+          task: parts[1],
+          gulpTask: parts.join('::')
+        };
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Resolve a Component Directory from the Root directory
+ *
+ * It will find the component directory containing "cu-build.config.js"
+ * It will only look into 3 directory levels, this should be enough depth for component nesting.
+ * The callback will receive (err, directory)
+ */
+function resolveComponentDirectory(root, component, callback) {
+  var path = require('path');
+  var fs = require('fs');
+  var globby = require('globby');
+
+  // search for the component containing a cu-build.config.js
+  var globs = [
+    root + '/' + component + '/cu-build.config.js',
+    root + '/*/' + component + '/cu-build.config.js',
+    root + '/*/*/' + component + '/cu-build.config.js'
+  ];
+
+  globby(globs, function (err, paths) {
+    if (err || paths.length == 0) {
+      callback('Could not find component: "' + component + '"', false);
+    } else {
+      callback(false, path.dirname(paths[0]));
+    }
+  });
+}
+
+/**
+ * Resolve all Component Directories from the Root directory
+ *
+ * It will find all component directories containing "cu-build.config.js"
+ * It will only look into 3 directory levels, this should be enough depth for component nesting.
+ * The callback will receive (err, directories)
+ */
+function findComponentDirectories(root, callback) {
+  var path = require('path');
+  var globby = require('globby');
+
+  // search for all components containing a cu-build.config.js
+  var globs = [
+    root + '/*/cu-build.config.js',
+    root + '/*/*/cu-build.config.js',
+    root + '/*/*/*/cu-build.config.js'
+  ];
+
+  globby(globs, function (err, paths) {
+    if (err || paths.length == 0) {
+      callback('Could not find components', false);
+    } else {
+      paths = paths.map(function (p) {
+        return path.dirname(p);
+      });
+      callback(false, paths);
+    }
+  });
+}
+
+/**
+ * Get arguments to pass to chug
+ *
+ * This will build a set of arguments ready to be passed to chug
+ */
+function getSubTaskArguments(options) {
+  var extend = require('extend');
+  var argv = require('minimist')(process.argv.slice(2));
+  if (options && options.args) {
+    extend(true, argv, options.args);
+  }
+  if (argv._) {
+    delete argv._;
+  }
+  var subArgs = [];
+
+  subArgs = subArgs.concat(createArgument(argv, 'port'));
+  subArgs = subArgs.concat(createArgument(argv, 'publish'));
+
+  return subArgs;
+}
+
+/**
+ * Create a chug argument
+ *
+ * This will convert an object argument into a switch for chug
+ * Example: {path: 'here'} will become ['--path', 'here']
+ */
+function createArgument(argv, argName) {
+  var args = [];
+  if (argv[argName]) {
+    args.push('--' + argName);
+    if (typeof argv[argName] != 'boolean') {
+      args.push(argv[argName]);
+    }
+  }
+  return args;
+}
+
+/**
+ * Execute a Sub Task on specific component
+ * Options:
+ *    path: the root path
+ *    component: the component to execute task on
+ *    task: the task to execute
+ *    args: the override arguments to pass to chug
+ */
+function executeTask(gulp, options, cb) {
+  var util = require('gulp-util');
+  var chug = require('gulp-chug');
+  var args = {};
+  if (options.args) {
+    args = options.args;
+  }
+  resolveComponentDirectory(options.path, options.component, execute);
+
+  function execute(err, componentDirectory) {
+    if (err) {
+      util.log(util.colors.red(err));
+      cb();
+    } else {
+      var stream = gulp.src(componentDirectory + '/gulpfile.js', { read: false })
+        .pipe(chug({
+          tasks: [options.task],
+          args: getSubTaskArguments({args: args})
+        }));
+      stream.on('end', function () {
+        cb();
+      });
+    }
+  }
+}
+
+/**
+ * Execute a Sub Task on all components
+ * Options:
+ *    path: the root path
+ *    task: the task to execute
+ *    args: the override arguments to pass to chug
+ */
+function executeTaskOnAllComponents(gulp, options, cb) {
+  var util = require('gulp-util');
+  var chug = require('gulp-chug');
+  var args = {};
+  if (options.args) {
+    args = options.args;
+  }
+  findComponentDirectories(options.path, function (err, components) {
+    if (err || components.length == 0) {
+      util.log(util.colors.red(err));
+      cb();
+    } else {
+      execute(components);
+    }
+  });
+
+  function execute(componentDirectories) {
+    componentDirectories = componentDirectories.map(function (componentDirectory) {
+      return componentDirectory + '/gulpfile.js';
+    });
+    var stream = gulp.src(componentDirectories, { read: false })
+      .pipe(chug({
+        tasks: [options.task],
+        args: getSubTaskArguments({args: args})
+      }));
+    stream.on('end', function () {
+      cb();
+    });
+  }
+}
+
+module.exports = {
+  resolveTask: resolveTask,
+  resolveComponentDirectory: resolveComponentDirectory,
+  findComponentDirectories: findComponentDirectories,
+  getSubTaskArguments: getSubTaskArguments,
+  executeTask: executeTask,
+  executeTaskOnAllComponents: executeTaskOnAllComponents
+};

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "extend": "3.0.0",
     "globby": "^2.1.0",
     "gulp-babel": "5.1.0",
+    "gulp-chug": "^0.4.2",
     "gulp-connect": "2.2.0",
     "gulp-debug": "^2.0.1",
     "gulp-eslint": "0.15.0",


### PR DESCRIPTION
I have made some improvements to the multi builder.

It will now use `gulp-chug` which should work much better than the previous setup.

It will provide the following tasks:

##### `gulp install`

This will install all the components production dependencies.

##### `gulp build`

This will build/publish all the components and legacy UI to the configured publish directory

##### `gulp component-name::task`

This will allow you to run any normal task on a component using the `::` syntax

---

It will also look for components in `node_modules` which would allow some libraries or components (located in external repositories) to be included in the build/publish.

There is a working example of this system here https://github.com/saddieeiddas/cu-ui/tree/ui-2 which can be setup via:

```sh
git clone https://github.com/saddieeiddas/cu-ui.git cu-ui-multi
cd cu-ui-multi
git checkout ui-2
npm install
gulp install
gulp build
```


