### PR TITLE
Adding the csproj generator as part of the Gulp build

### DIFF
--- a/lib/builder/builder.js
+++ b/lib/builder/builder.js
@@ -21,7 +21,8 @@ module.exports = function (gulp, options) {
   var config = require('./../util/config')(options);
   var prefix = require('./../util/prefix')(config.task_prefix);
   var sequence = require('run-sequence').use(gulp);
-  var argv = require('minimist')(process.argv.slice(2));
+  var vsgen = require('./../util/vsgen');
+  var path = require('path');
 
   gulp.task(prefix('watch-server'), [prefix('watch'), prefix('server')]);
 
@@ -43,6 +44,7 @@ module.exports = function (gulp, options) {
       prefix('lint'),
       prefix('compile'),
       [
+        'vsgen',
         prefix('bundle'),
         prefix('stylus'),
         prefix('definitions'),
@@ -117,6 +119,28 @@ module.exports = function (gulp, options) {
       return plugins.merge2([
         result.js.pipe(plugins.sourcemaps.write({sourceRoot: '../',includeContent: true})).pipe(gulp.dest(config.dir.tmp))
       ]);
+    }
+  });
+  
+  gulp.task('vsgen', function(cb) {
+    if (config.build.vsgen) {
+      var all = [];
+      for (var p in config.glob) {
+        all = all.concat(config.glob[p]);
+      }
+      
+      var proj = config.proj_name || config.name;
+      var ext = path.extname(proj);
+      if (!ext || ext === '') {
+        proj += '.csproj';
+      }
+      proj = path.join(config.path, proj);
+      
+      return gulp.src(all, {base: config.path})
+        .pipe(vsgen(proj))
+        .on('error', plugins.util.log);
+    } else {
+      cb();
     }
   });
 

--- a/lib/content/template.proj
+++ b/lib/content/template.proj
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?><Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <ProjectGuid>{6AE2C434-CAB1-4A81-BF8B-4D6F6CC8194F}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <OutputPath>bin</OutputPath>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <TypeScriptToolsVersion>1.6</TypeScriptToolsVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <IISExpressSSLPort/>
+    <IISExpressAnonymousAuthentication/>
+    <IISExpressWindowsAuthentication/>
+    <IISExpressUseClassicPipelineMode/>
+    <TypeScriptTarget>ES5</TypeScriptTarget>
+    <TypeScriptRemoveComments>false</TypeScriptRemoveComments>
+    <TypeScriptAdditionalFlags>--jsx react</TypeScriptAdditionalFlags>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <TypeScriptSourceMap>true</TypeScriptSourceMap>
+    <TypeScriptModuleKind>AMD</TypeScriptModuleKind>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <TypeScriptSourceMap>false</TypeScriptSourceMap>
+    <TypeScriptModuleKind>AMD</TypeScriptModuleKind>
+  </PropertyGroup>
+  <ItemGroup id="vsgen-target">
+  
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RootNamespace>UI</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets"/>
+  <Import Project="$(VSToolsPath)\TypeScript\Microsoft.TypeScript.targets" Condition="Exists('$(VSToolsPath)\TypeScript\Microsoft.TypeScript.targets')"/>
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''"/>
+  <Import Project="$(MSBuildProjectDirectory)\msbuild\gulp.targets" />
+  
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>False</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>1336</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:1336/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  
+  <!-- ************* GULP BUILD ************* -->
+  <Target Name="Node">
+        <Exec Command="$(WINDIR)\system32\where.exe node"
+            ContinueOnError="true"
+            IgnoreExitCode="true"
+            ConsoleToMsBuild="true">
+            <Output TaskParameter="ExitCode" PropertyName="ExecExitCode"/>
+            <Output TaskParameter="ConsoleOutput" PropertyName="NodePath" />
+        </Exec>
+        
+        <PropertyGroup Condition=" '$(ExecExitCode)' == '0' AND '$(NodePath)' != '' ">
+            <NodePath>$([System.IO.Path]::GetDirectoryName('$(NodePath)'))</NodePath>
+        </PropertyGroup>
+        
+        <Error Condition=" '$(NodePath)' == '' OR !Exists('$(NodePath)') " Text="Node.js is not installed, please install it from https://nodejs.org/." />
+    </Target>
+
+    <Target Name="Gulp" DependsOnTargets="Node">
+        <Exec Command="$(WINDIR)\system32\where.exe gulp.cmd"
+            ContinueOnError="true"
+            IgnoreExitCode="true"
+            ConsoleToMsBuild="true">
+            <Output TaskParameter="ExitCode" PropertyName="ExecExitCode"/>
+            <Output TaskParameter="ConsoleOutput" PropertyName="GulpPath" />
+        </Exec>
+        
+        <Message Importance="high" Text="Installing Gulp..." Condition=" '$(GulpPath)' == '' OR !Exists('$(GulpPath)') " />
+        
+        <Exec Command='$(WINDIR)\system32\cmd.exe /C ""$(NodePath)\npm.cmd" install -g gulp"'
+            IgnoreExitCode="true"
+            Condition=" '$(GulpPath)' == '' OR !Exists('$(GulpPath)') ">
+            <Output TaskParameter="ExitCode" PropertyName="ExecExitCode"/>
+        </Exec>
+        
+        <Error Condition=" '$(ExecExitCode)' != '0' " Text="Failed to automatically install Gulp, please run `npm install gulp -g` from a commandline." />
+                
+        <Exec Command="$(WINDIR)\system32\where.exe gulp.cmd"
+            ContinueOnError="true"
+            IgnoreExitCode="true"
+            ConsoleToMsBuild="true"
+            Condition=" '$(GulpPath)' == '' OR !Exists('$(GulpPath)') ">
+            <Output TaskParameter="ExitCode" PropertyName="ExecExitCode"/>
+            <Output TaskParameter="ConsoleOutput" PropertyName="GulpPath" />
+        </Exec>
+        
+        <Error Condition=" '$(GulpPath)' == '' OR !Exists('$(GulpPath)') " Text="Can't find Gulp even after installing it, please run `npm install gulp -g` from a commandline." />
+        
+        <PropertyGroup Condition=" '$(GulpPath)' != '' ">
+            <GulpPath>$([System.IO.Path]::GetDirectoryName('$(GulpPath)'))</GulpPath>
+        </PropertyGroup>
+    </Target>
+    
+    <Target Name="GulpBuild" DependsOnTargets="Gulp" BeforeTargets="Build">
+        <Exec Command=' $(WINDIR)\system32\cmd.exe /C ""$(GulpPath)\gulp.cmd" build --vsgen false" '
+            ContinueOnError="true"
+            IgnoreExitCode="true"
+            WorkingDirectory="$(MSBuildProjectDirectory)" >
+            <Output TaskParameter="ExitCode" PropertyName="ExecExitCode"/>
+        </Exec>
+        <Error Condition=" '$(ExecExitCode)' != '0' " Text="Gulp indicated a failure." />
+    </Target>
+  
+</Project>

--- a/lib/util/config.js
+++ b/lib/util/config.js
@@ -35,6 +35,7 @@ module.exports = function(custom) {
     },
     main_name: 'main',
     bundle_name: false,
+    proj_name: false,
     name: false,
     file: {
       main: false,
@@ -46,7 +47,8 @@ module.exports = function(custom) {
       port: 9000
     },
     build: {
-      compress: false
+      compress: false,
+      vsgen: true
     },
     legacy: false,
     exclude: [],
@@ -175,6 +177,10 @@ module.exports = function(custom) {
 
     if (argv.publish) {
       config.build_type = 'publish';
+    }
+  
+    if (argv.vsgen === 'false') {
+      config.build.vsgen = false;
     }
 
     config.processed = true;

--- a/lib/util/vsgen.js
+++ b/lib/util/vsgen.js
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ 
+var through = require('through2'); 
+var path = require('path'); 
+var fs = require('fs');
+var gutil = require('gulp-util'); 
+var extend = require('extend');
+var PluginError = gutil.PluginError; 
+var File = gutil.File; 
+var xmldom = require('xmldom');
+var DOMParser = xmldom.DOMParser;
+var XMLSerializer = xmldom.XMLSerializer;
+
+module.exports = function(proj, opt) { 
+  if (!proj) { 
+    throw new PluginError('vsgen', 'Missing proj parameter for vsgen'); 
+  } 
+  
+  var config = {
+    tags: {
+      '.ts': 'TypeScriptCompile',
+      '.tsx': 'TypeScriptCompile',
+      '..': 'Content'
+    },
+    template: path.join(__dirname, '..', 'content', 'template.proj')
+  };
+  extend(true, config, opt);
+  
+  var files = [];
+  
+  function bufferContent(file, enc, cb) {
+    if(file.isNull()) {
+      cb();
+      return;  
+    }
+    
+    files.push(file.relative);
+    cb();
+  }
+    
+  function endStream(cb) {
+    var that = this;
+    fs.readFile(config.template, 'utf8', function (err, content) {
+      if (err) {
+        that.emit('error', err);
+        cb();
+        return;
+      }
+      
+      try {
+      
+        var dom = new DOMParser().parseFromString(content);
+        var target = dom.getElementById('vsgen-target');
+        
+        if (!target) {
+          throw new PluginError('vsgen', 'Could not find vsgen-target element'); 
+        }
+        target.removeAttribute('id'); // VS or MSBuild might not like this.
+        
+        for (var i = 0; i < files.length; i++) {
+          var file = files[i];
+          var ext = path.extname(file);
+          var tagName = config.tags['..'];
+          if (config.tags.hasOwnProperty(ext)) {
+            tagName = config.tags[ext];
+          }
+          
+          var element = dom.createElementNS(target.namespaceURI, tagName);
+          element.setAttribute('Include', file);
+          target.appendChild(element);
+        }
+        
+        content = new XMLSerializer().serializeToString(dom);
+        fs.writeFile(proj, content, 'utf8', function(err) {
+          if (err) {
+            that.emit('error', err);
+          }
+          cb();
+        });
+      
+      } catch (err) {
+        that.emit('error', err);
+        cb();
+      }
+    });
+  }
+  
+  return through.obj(bufferContent, endStream);
+}

--- a/package.json
+++ b/package.json
@@ -39,8 +39,10 @@
     "ntypescript": "^1.201508010031.1",
     "q": "^1.4.1",
     "run-sequence": "1.1.2",
+    "through2": "^2.0.0",
     "time-require": "^0.1.2",
     "vinyl-buffer": "1.0.0",
-    "vinyl-source-stream": "1.1.0"
+    "vinyl-source-stream": "1.1.0",
+    "xmldom": "^0.1.19"
   }
 }


### PR DESCRIPTION
This is the initial .csproj generator. It will create a .csproj (for the VS guys) that contains all the files that were part of the build. Note that this is always done to guarantee that anyone who pulls down the code will have an up-to-date .csproj.

## lib/builder/builder.js

Simply added the `vsgen` task that calls out to the `vsgen` require. Note that vsgen is always called, regardless of prod/dev.

## template.proj

This is the default .csproj which the includes are inserted into.

## lib/util/vsgen.js

The gulp plugin that creates the .csproj from a set of files.

## Limitations

VS2015 is currently completely breaking due to the package.json. Regardless of that, this project can be opened. We're going to have to see what VS2015 update 1 brings. The MSBuild script still needs work (create structure in dist dir) but I'm unable to complete that due to the VS2015 bugs.